### PR TITLE
Write all logs in pyrsia_node.log instead of pyrsia_node_err.log

### DIFF
--- a/Formula/pyrsia.rb
+++ b/Formula/pyrsia.rb
@@ -40,7 +40,7 @@ class Pyrsia < Formula
     process_type :background
     environment_variables envvarhash
     log_path var/"pyrsia/logs/stdout/pyrsia_node.log"
-    error_log_path var/"pyrsia/logs/stderr/pyrsia_node_err.log"
+    error_log_path var/"pyrsia/logs/stdout/pyrsia_node.log"
     working_dir var/"pyrsia"
   end
 


### PR DESCRIPTION
Issue: https://github.com/pyrsia/pyrsia/issues/1323
Related to https://github.com/pyrsia/pyrsia/pull/1312

Changed the log paths because currently all logs including info and debug are written in the error log file.
If Pyrsia gets to send logs to stdout (now stderr), this change can be reverted.

Confirmed the logs were written properly at the local env.
```
$ tail -f /usr/local/var/pyrsia/logs/stdout/pyrsia_node.log                                                                           (git)-[change-the-log-paths]
 2022-11-28T21:37:46.834Z DEBUG pyrsia_node > Create artifact service
 2022-11-28T21:37:46.834Z DEBUG pyrsia_node > Create build service
 2022-11-28T21:37:46.835Z DEBUG pyrsia_node > Create verification service
 2022-11-28T21:37:46.835Z DEBUG pyrsia_node > Start build event loop
 2022-11-28T21:37:46.835Z DEBUG pyrsia_node > Setup HTTP server
 2022-11-28T21:37:46.835Z DEBUG pyrsia_node > Pyrsia Docker Node will bind to host = 127.0.0.1, port = 7888
 2022-11-28T21:37:46.835Z DEBUG pyrsia_node > Setup HTTP routing
 2022-11-28T21:37:46.835Z DEBUG pyrsia_node > Setup HTTP server
thread 'main' panicked at 'error binding to 127.0.0.1:7888: error creating server listener: Address already in use (os error 48)', /Users/manasd/.cargo/registry/src/github.com-1ecc6299db9ec823/warp-0.3.2/src/server.rs:213:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```